### PR TITLE
Installation and installation prefix

### DIFF
--- a/QtAwesome/QtAwesome.pro
+++ b/QtAwesome/QtAwesome.pro
@@ -11,5 +11,18 @@ CONFIG += staticlib
 SOURCES += QtAwesome.cpp
 HEADERS += QtAwesome.h
 
+isEmpty(PREFIX) {
+    unix {
+        PREFIX = /usr
+    } else {
+        PREFIX = $$[QT_INSTALL_PREFIX]
+    }
+}
+
+install_headers.files = QtAwesome.h
+install_headers.path = $$PREFIX/include
+target.path = $$PREFIX/lib
+INSTALLS += install_headers target
+
 RESOURCES += \
     QtAwesome.qrc


### PR DESCRIPTION
Added an option to install the library using `make install` - for those of us whose build system requires it and those who don't like to include dependencies in their codebase.
