### PR TITLE
rename fa::linux to fa::_linux to avoid name conflict with linux system #defines

### DIFF
--- a/QtAwesome/QtAwesome.cpp
+++ b/QtAwesome/QtAwesome.cpp
@@ -568,7 +568,7 @@ bool QtAwesome::initFontAwesome( )
     m.insert("link", fa::link );
     m.insert("linkedin", fa::linkedin );
     m.insert("linkedinsquare", fa::linkedinsquare );
-    m.insert("linux", fa::linux );
+    m.insert("linux", fa::_linux );
     m.insert("list", fa::list );
     m.insert("listalt", fa::listalt );
     m.insert("listol", fa::listol );

--- a/QtAwesome/QtAwesome.h
+++ b/QtAwesome/QtAwesome.h
@@ -391,7 +391,7 @@ namespace fa {
       link                 = 0xf0c1,
       linkedin             = 0xf0e1,
       linkedinsquare       = 0xf08c,
-      linux                = 0xf17c,
+      _linux               = 0xf17c,
       list                 = 0xf03a,
       listalt              = 0xf022,
       listol               = 0xf0cb,


### PR DESCRIPTION
GCC and clang compilers on Linux define the following macro:

```c
#define linux 1
```

This conflicts with the `linux` value in the `QtAwesome.h` header.