### PR TITLE
Finish intialization in the constructor

### DIFF
--- a/QtAwesome/QtAwesome.h
+++ b/QtAwesome/QtAwesome.h
@@ -18,6 +18,7 @@
 #include <QRect>
 #include <QVariantMap>
 
+#include <stdexcept>
 
 /// A list of all icon-names with the codepoint (unicode-value) on the right
 /// You can use the names on the page  http://fortawesome.github.io/Font-Awesome/design.html
@@ -735,10 +736,10 @@ Q_OBJECT
 public:
 
     QtAwesome(QObject *parent = 0);
-    virtual ~QtAwesome();
+    QtAwesome(const QString &fontname, QObject *parent = 0);
+    // Destructor is virtual because the destructor of the base class is virtual
+    ~QtAwesome();
 
-    void init( const QString& fontname );
-    bool initFontAwesome();
 
     void addNamedCodepoint( const QString& name, int codePoint );
     QHash<QString,int> namedCodePoints() { return namedCodepoints_; }
@@ -764,6 +765,10 @@ private:
     QHash<QString, QtAwesomeIconPainter*> painterMap_;     ///< A map of custom painters
     QVariantMap defaultOptions_;                           ///< The default icon options
     QtAwesomeIconPainter* fontIconPainter_;                ///< A special painter fo painting codepoints
+
+    void init( const QString& fontname );
+    void initFontAwesome();
+    void setDefaultOptions();
 };
 
 

--- a/QtAwesomeSample/main.cpp
+++ b/QtAwesomeSample/main.cpp
@@ -17,7 +17,6 @@ int main(int argc, char *argv[])
     QMainWindow w;
 
     QtAwesome* awesome = new QtAwesome(&w);
-    awesome->initFontAwesome();
 
     // a simple beer button
     QPushButton* beerButton = new QPushButton( "Cheers!");

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ You probably want to create a single QtAwesome object for your whole application
 
 ````
     QtAwesome* awesome = new QtAwesome( qApp )
-    awesome->initFontAwesome();     // This line is important as it loads the font and initializes the named icon map
 
 ````
 
@@ -63,7 +62,6 @@ Example
 ```c++
 // You should create a single object of QtAwesome.
 QtAwesome* awesome = new QtAwesome( qApp );
-awesome->initFontAwesome();
 
 // Next create your icon with the help of the icon-enumeration (no dashes): 
 QPushButton* beerButton new QPushButton( awesome->icon( fa::beer ), "Cheers!" );


### PR DESCRIPTION
I think that having the possibility to construct a QtAwesome object
that is only in a half-initialized state isn't very useful.

Having to construct and call an init function directly after that
isn't C++ idiomatic.

Also, eliminating the explicit init() function makes the API harder
to misuse.

See also:

http://stackoverflow.com/a/3786967/427158