### PR TITLE
Add cmake support

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/QtAwesome.iml
+++ b/.idea/QtAwesome.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="CPP_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/QtAwesome.iml" filepath="$PROJECT_DIR$/.idea/QtAwesome.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/QtAwesome/CMakeLists.txt
+++ b/QtAwesome/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+set(HEADER_FILES
+        QtAwesome.h
+        QtAwesomeAnim.h)
+
+set(SOURCE_FILES
+        QtAwesome.cpp
+        QtAwesomeAnim.cpp)
+
+find_package(Qt5 REQUIRED Core Gui Widgets)
+QT5_ADD_RESOURCES(RESOURCE_FILES
+        QtAwesome.qrc)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTORCC ON)
+find_package(Qt5 REQUIRED Core Gui Widgets)
+
+add_library(QtAwesome ${HEADER_FILES} ${SOURCE_FILES} ${RESOURCE_FILES})
+target_link_libraries(QtAwesome Qt5::Core Qt5::Gui Qt5::Widgets)
+target_include_directories(QtAwesome PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ project tree and add the following `include()` to your Qt project file:
 
 Now you are good to go!
 
+or, if you use `cmake` for build add to your `CMakeLists.txt`:
+
+````
+  add_subdirectory(path/to/QtAwesome/QtAwesome QtAwesome)
+  target_link_libraries(${YOUR_PROJECT_NAME} QtAwesome)
+````
 
 Usage
 -----


### PR DESCRIPTION
It's a very long time that previous pull request #22 not update.

So I modified the cmake script, add line 
```
target_include_directories(QtAwesome PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
```

So the cmake can include the QtAwesome directory automatic.