### PR TITLE
Move CMakeLists.txt to root directory

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,6 @@ jobs:
 
     name: ${{ matrix.os }}-Qt-${{ matrix.qt_version }}-shared-${{ matrix.shared }}
     runs-on: ${{ matrix.os }}
-    
 
     strategy:
       fail-fast: false
@@ -41,7 +40,7 @@ jobs:
         dir: ${{ github.workspace }}/Qt
 
     - name: Configure (${{ matrix.configuration }})
-      run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=${{ matrix.shared }} -B "${{github.workspace}}/build" -S "QtAwesome"
+      run: cmake -DCMAKE_BUILD_TYPE="${{env.BUILD_TYPE}}" -DBUILD_SHARED_LIBS=${{ matrix.shared }} -B "${{github.workspace}}/build"
 
     - name: Build with ${{ matrix.compiler }}
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,13 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_library(QtAwesome
-  QtAwesome.cpp
-  QtAwesomeAnim.cpp
-  QtAwesomeFree.qrc
+  QtAwesome/QtAwesome.cpp
+  QtAwesome/QtAwesomeAnim.cpp
+  QtAwesome/QtAwesomeFree.qrc
 )
 
 target_include_directories(QtAwesome
-  INTERFACE ${PROJECT_SOURCE_DIR}
+  INTERFACE ${PROJECT_SOURCE_DIR}/QtAwesome
 )
 
 target_link_libraries(QtAwesome PUBLIC


### PR DESCRIPTION
I was thinking it would be maybe better to have the CMakeLists.txt file in the root directory.

It seems to be quite standard for a C++ project and it allow me to have the simple `CMakeLists.txt` file in my `vendors/` folder:

```cmake
add_subdirectory(QtAwesome)
...
```