### PR TITLE
Force static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_AUTORCC ON)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
-add_library(QtAwesome
+add_library(QtAwesome STATIC
 	QtAwesome/QtAwesome.h
 	QtAwesome/QtAwesome.cpp
 	QtAwesome/QtAwesomeAnim.h


### PR DESCRIPTION
I'm not sure this changed should be accepted but I needed this patch to make sure the library compiles statically. Indeed, I have BUILD_SHARED_LIBS set to ON globally on my project so it is propagated to QtAwesome which lead to a compile error.

I'm sure there is a cleaner way to handle this situation.