### PR TITLE
add support for dark/light mode switch

### DIFF
--- a/QtAwesome/QtAwesome.cpp
+++ b/QtAwesome/QtAwesome.cpp
@@ -17,6 +17,7 @@
 #include <QFontDatabase>
 #include <QFontMetrics>
 #include <QString>
+#include <QStyleHints>
 
 
 // Initializing namespaces need to happen outside a namespace
@@ -228,24 +229,8 @@ QtAwesome::QtAwesome(QObject* parent)
     , _namedCodepointsByStyle()
     , _namedCodepointsList()
 {
-      setDefaultOption("color", QApplication::palette().color(QPalette::Normal, QPalette::Text));
-      setDefaultOption("color-disabled", QApplication::palette().color(QPalette::Disabled, QPalette::Text));
-      setDefaultOption("color-active", QApplication::palette().color(QPalette::Active, QPalette::Text));
-      setDefaultOption("color-selected", QApplication::palette().color(QPalette::Active, QPalette::Text));  // TODO: check how to get the correct highlighted color
-      setDefaultOption("scale-factor", 1.0 );
 
-
-#ifdef FONT_AWESOME_PRO
-      setDefaultOption("duotone-color", QApplication::palette().color(QPalette::Normal, QPalette::BrightText) );
-      setDefaultOption("duotone-color-disabled",
-                       QApplication::palette().color(QPalette::Disabled, QPalette::BrightText));
-      setDefaultOption("duotone-color-active", QApplication::palette().color(QPalette::Active, QPalette::BrightText));
-      setDefaultOption("duotone-color-selected", QApplication::palette().color(QPalette::Active, QPalette::BrightText));
-#endif
-    setDefaultOption("text", QVariant());
-    setDefaultOption("text-disabled", QVariant());
-    setDefaultOption("text-active", QVariant());
-    setDefaultOption("text-selected", QVariant());
+    resetDefaultOptions();
 
     _fontIconPainter = new QtAwesomeCharIconPainter();
 
@@ -261,6 +246,36 @@ QtAwesome::QtAwesome(QObject* parent)
     _fontDetails.insert(fa::fa_sharp_light, QtAwesomeFontData(FA_SHARP_LIGHT_FONT_FILENAME, FA_SHARP_LIGHT_FONT_WEIGHT));
     _fontDetails.insert(fa::fa_sharp_thin, QtAwesomeFontData(FA_SHARP_THIN_FONT_FILENAME, FA_SHARP_THIN_FONT_WEIGHT));
 #endif
+
+    // support dark/light mode
+    QObject::connect(QApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, [this](Qt::ColorScheme colorScheme){
+        resetDefaultOptions();
+    });
+}
+
+void QtAwesome::resetDefaultOptions(){
+    _defaultOptions.clear();
+
+    setDefaultOption("color", QApplication::palette().color(QPalette::Normal, QPalette::Text));
+    setDefaultOption("color-disabled", QApplication::palette().color(QPalette::Disabled, QPalette::Text));
+    setDefaultOption("color-active", QApplication::palette().color(QPalette::Active, QPalette::Text));
+    setDefaultOption("color-selected", QApplication::palette().color(QPalette::Active, QPalette::Text));  // TODO: check how to get the correct highlighted color
+    setDefaultOption("scale-factor", 1.0 );
+
+
+#ifdef FONT_AWESOME_PRO
+    setDefaultOption("duotone-color", QApplication::palette().color(QPalette::Normal, QPalette::BrightText) );
+    setDefaultOption("duotone-color-disabled",
+                     QApplication::palette().color(QPalette::Disabled, QPalette::BrightText));
+    setDefaultOption("duotone-color-active", QApplication::palette().color(QPalette::Active, QPalette::BrightText));
+    setDefaultOption("duotone-color-selected", QApplication::palette().color(QPalette::Active, QPalette::BrightText));
+#endif
+    setDefaultOption("text", QVariant());
+    setDefaultOption("text-disabled", QVariant());
+    setDefaultOption("text-active", QVariant());
+    setDefaultOption("text-selected", QVariant());
+
+    Q_EMIT defaultOptionsReset();
 }
 
 QtAwesome::~QtAwesome()

--- a/QtAwesome/QtAwesome.h
+++ b/QtAwesome/QtAwesome.h
@@ -131,6 +131,14 @@ protected:
     const QString styleEnumToString(int style) const;
     void addToNamedCodePoints(int style, const fa::QtAwesomeNamedIcon* faCommonIconArray, int size);
 
+Q_SIGNALS:
+    // signal about default options being reset
+    void defaultOptionsReset();
+
+public Q_SLOTS:
+    // (re)set default options according to current QApplication::palette()
+    void resetDefaultOptions();
+
 private:
     QHash<int, QtAwesomeFontData>     _fontDetails;           ///< The fonts name used for each style
     QHash<int, QHash<QString, int>*> _namedCodepointsByStyle; ///< A map with names mapped to code-points for each style

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ icons to your [Qt application](http://qt-project.org/).
 
 ## Table of Contents
 
-- [Latest Release 6.4.2](#latest-release-642)
+- [Latest Release 6.5.1](#latest-release-651)
 - [Font Awesome 6 Release](#font-awesome-6-release)
 - [Installation Free Version](#installation-free-version)
 - [Installation Pro version](#installation-pro-version)


### PR DESCRIPTION
QtAwesome `setDefaultOption` for all default colors inside constructor. When using single instance of  QtAwesome and use swithes between dark/light theme, the icon color stay unchanged. Another case is calling QApplication::setPalette.
I'm trying to find a way to let QtAwesome and other QObject knows about the change to fix the problem.