### PR TITLE
Action updates

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
         version: ${{ matrix.qt_version }}
         cache: 'true'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,11 +22,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-12, macos-13, windows-2019, windows-2022]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-12, macos-13, macos-14, windows-2019, windows-2022]
         qt_version: [5.12.12, 5.15.2, 6.4.0, 6.5.0, 6.6.0, 6.7.0]
         shared: [ON, OFF]
-
+        exclude:
+          - os: macos-14
+            qt_version: 5.12.12
+          - os: macos-14
+            qt_version: 5.15.2
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
 
-        os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-13, windows-2019, windows-2022]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-12, macos-13, windows-2019, windows-2022]
         qt_version: [5.12.12, 5.15.2, 6.4.0]
         shared: [ON, OFF]
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
 
         os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-12, macos-13, windows-2019, windows-2022]
-        qt_version: [5.12.12, 5.15.2, 6.4.0]
+        qt_version: [5.12.12, 5.15.2, 6.4.0, 6.5.0, 6.6.0, 6.7.0]
         shared: [ON, OFF]
 
     steps:


### PR DESCRIPTION
Update the version of actions used in the build job

 - Use Checkout Action v4
 - Use Qt Install Action v4
 - Add Ubuntu 24.04
 - Add Mac os 14 (only Qt6 supported)
 - Add Qt 6.5 - 6.7