### PR TITLE
Support to Qt6.9.Fix the CmakeLists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.pro.user
 *.pro.user*
 CMakeLists.txt.user
-*/build
+**/build
 
 # never include pro files
 QtAwesome/fonts/pro/

--- a/QtAwesomeSample/CMakeLists.txt
+++ b/QtAwesomeSample/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-add_subdirectory(../QtAwesome QtAwesome)
+add_subdirectory(../ QtAwesome)
 
 add_executable(QtAwesomeSample
   mainwindow.cpp

--- a/QtAwesomeSample/LICENSE.md
+++ b/QtAwesomeSample/LICENSE.md
@@ -1,0 +1,37 @@
+MIT License
+===========
+
+Copyright 2013-2022 [Reliable Bits Software by Blommers IT](https://blommersit.nl). All Rights Reserved.
+Author [Rick Blommers](mailto:rick@blommersit.nl)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+Font Awesome License
+====================
+
+[https://github.com/FortAwesome/Font-Awesome](https://github.com/FortAwesome/Font-Awesome)
+
+Font Awesome Free is free, open source, and GPL friendly. You can use it for commercial projects,
+open source projects, or really almost whatever you want.
+
+- Icons — CC BY 4.0 License
+In the Font Awesome Free download, the CC BY 4.0 license applies to all icons packaged as .svg and .js files types.
+- Fonts — SIL OFL 1.1 License
+In the Font Awesome Free download, the SIL OLF license applies to all icons packaged as web and desktop font files.
+- Code — MIT License
+In the Font Awesome Free download, the MIT license applies to all non-font and non-icon files.
+Attribution is required by MIT, SIL OLF, and CC BY licenses. Downloaded Font Awesome Free files already contain embedded comments with sufficient attribution, so you shouldn't need to do anything additional when using these files normally.
+
+We've kept attribution comments terse, so we ask that you do not actively work to remove them from files,
+especially code. They're a great way for folks to learn about Font Awesome.

--- a/QtAwesomeSample/mainwindow.cpp
+++ b/QtAwesomeSample/mainwindow.cpp
@@ -4,6 +4,7 @@
 #include <QStandardItemModel>
 #include <QMap>
 #include <QDebug>
+#include <QtCore/qtypes.h>
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -57,7 +58,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
         QVariantMap options;
         options.insert("color", QColor(Qt::yellow));
-        options.insert("text-off", QString(fa::fa_square));
+        options.insert("text-off", QString(QChar(static_cast<quint16>(fa::fa_square))));
         options.insert("color-off", QColor(Qt::darkBlue));
         toggleButton->setIcon( awesome->icon("fa_solid square-check", options));
     }


### PR DESCRIPTION
Refines .gitignore to globally ignore build directories and corrects the CMake add_subdirectory path.

Support to Qt6.9
Ensures proper icon rendering by including qtypes and converting the FontAwesome codepoint to QChar.